### PR TITLE
Fix uninitialized variable

### DIFF
--- a/ym7101psg.c
+++ b/ym7101psg.c
@@ -132,7 +132,7 @@ void PSG_UpdateSample(psg_t *chip)
 
 Bit16u PSG_Read(psg_t *chip)
 {
-    Bit16u sample;
+    Bit16u sample = 0;
     Bit32u i;
     PSG_UpdateSample(chip);
     for (i = 0; i < 4; i++)


### PR DESCRIPTION
programming error in `PSG_Read` where sample has not been initialized